### PR TITLE
upgrade to kafka 10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.9.0.0</version>
+            <version>0.10.2.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -82,8 +82,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
-            <version>0.9.0.0</version>
+            <artifactId>kafka_2.12</artifactId>
+            <version>0.10.2.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -225,6 +225,22 @@
                 <configuration>
                     <repoToken>${COVERALL_TOKEN}</repoToken>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <configuration>
+                    <!-- put your configurations here -->
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/github/danielwegener/logback/kafka/util/EmbeddedKafkaCluster.java
+++ b/src/test/java/com/github/danielwegener/logback/kafka/util/EmbeddedKafkaCluster.java
@@ -1,8 +1,11 @@
 package com.github.danielwegener.logback.kafka.util;
 
+import kafka.metrics.KafkaMetricsReporter;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
+import org.apache.kafka.common.utils.Time;
 import scala.Some;
+import scala.collection.JavaConversions;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -89,7 +92,7 @@ public class EmbeddedKafkaCluster {
 
 
     private KafkaServer startBroker(Properties props) {
-        KafkaServer server = new KafkaServer(new KafkaConfig(props), new SystemTime(), Some.apply("embedded-kafka-cluster"));
+        KafkaServer server = new KafkaServer(new KafkaConfig(props), Time.SYSTEM, Some.apply("embedded-kafka-cluster"), JavaConversions.asScalaBuffer(new ArrayList<KafkaMetricsReporter>()).toSeq());
         server.startup();
         return server;
     }

--- a/src/test/java/com/github/danielwegener/logback/kafka/util/SystemTime.java
+++ b/src/test/java/com/github/danielwegener/logback/kafka/util/SystemTime.java
@@ -1,6 +1,6 @@
 package com.github.danielwegener.logback.kafka.util;
 
-import kafka.utils.Time;
+import org.apache.kafka.common.utils.Time;
 
 class SystemTime implements Time {
     public long milliseconds() {
@@ -17,5 +17,10 @@ class SystemTime implements Time {
         } catch (InterruptedException e) {
             // Ignore
         }
+    }
+
+    @Override
+    public long hiResClockMs() {
+        return 0;
     }
 }


### PR DESCRIPTION
Upgraded to latest kafka libraries to make log entries compatible with 0.10.0.0 message formats (the timestamping) to be compatible with 0.10.0.0 clients.